### PR TITLE
Update compile version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Para exemplos, verifique os testes na pasta sample.
 
 ## Gradle
 
-`compile 'br.com.concretesolutions:canarinho:1.1.0'`
+`compile 'br.com.concretesolutions:canarinho:1.2.0'`
 
 ## ATENÇÃO
 


### PR DESCRIPTION
Para usar o Builder do ValorMonetarioWatcher precisa usar a versao 1.2.0 da biblioteca, conforme atualização