### PR TITLE
Corrige desformatar simbolo real

### DIFF
--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorValor.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorValor.java
@@ -67,7 +67,7 @@ public final class FormatadorValor implements Formatador {
 
         String realValue = value;
         if (value.startsWith(SIMBOLO_REAL)) {
-            realValue = value.substring(value.indexOf(SIMBOLO_REAL));
+            realValue = value.substring(SIMBOLO_REAL.length());
         }
 
         final BigDecimal valor = (BigDecimal) FORMATADOR_MOEDA.parse(realValue,


### PR DESCRIPTION
Dentro do if o indice do  simbolo real sempre será 0, logo utilizar apenas o seu tamanho para o substring é valido.

## Type of Change 
- [X] Bug fix 
- [ ] New Feature 
- [ ] Improvement
- [ ] Other? 

