### PR TITLE
Extrai constantes da interface para uma classe própria

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Estes são utilizados para implementar `TextWatcher`s que formatam e validam a d
 ### Validar um CPF
 
 ```java
-if (Validador.CPF.ehValido(cpf))
+if (Validador.Constantes.CPF.ehValido(cpf))
     Toast.makeText(context, "Válido!", Toast.LENGTH_SHORT).show();
 else
     Toast.makeText(context, "Inválido!", Toast.LENGTH_SHORT).show();
@@ -34,7 +34,7 @@ else
 ### Formatar um CPF
 
 ```java
-String cpfFormatado = Formatador.CPF.formata(usuario.getCpf());
+String cpfFormatado = Formatador.Constantes.CPF.formata(usuario.getCpf());
 ```
 
 ### Formatar um EditText para CPF sem validação
@@ -49,7 +49,7 @@ cpfEditText.addTextChangedListener(new MascaraNumericaTextWatcher("###.###.###-#
 cpfEditText.addTextChangedListener(new MascaraNumericaTextWatcher.Builder()
                                         .paraMascara("###.###.###-##")
                                         .comCallbackDeValidacao(new SampleEventoDeValidacao(context))
-                                        .comValidador(Validador.CPF)
+                                        .comValidador(Validador.Constantes.CPF)
                                         .build());
 ```
 

--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/Formatador.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/Formatador.java
@@ -8,68 +8,6 @@ import java.util.regex.Pattern;
  */
 public interface Formatador {
 
-    // Formatadores
-    /**
-     * Singleton de formatação de CEP.
-     */
-    Formatador CEP = new FormatadorBase(
-            Padroes.CEP_FORMATADO,
-            "$1-$2",
-            Padroes.CEP_DESFORMATADO,
-            "$1$2"
-    );
-
-    /**
-     * Singleton de formatação de CPF.
-     */
-    Formatador CPF = new FormatadorBase(
-            Padroes.CPF_FORMATADO,
-            "$1.$2.$3-$4",
-            Padroes.CPF_DESFORMATADO,
-            "$1$2$3$4"
-    );
-
-    /**
-     * Singleton de formatação de CNPJ.
-     */
-    Formatador CNPJ = new FormatadorBase(
-            Padroes.CNPJ_FORMATADO,
-            "$1.$2.$3/$4-$5",
-            Padroes.CNPJ_DESFORMATADO,
-            "$1$2$3$4$5"
-    );
-
-    /**
-     * Singleton de formatação de CPF e CNPJ.
-     */
-    Formatador CPF_CNPJ = FormatadorCPFCNPJ.getInstance();
-
-    /**
-     * Singleton de formatação de valores monetários.
-     */
-    FormatadorValor VALOR = FormatadorValor.getInstance(false);
-
-    /**
-     * Singleton de formatação de valores monetários com símbolo do Real.
-     */
-    FormatadorValor VALOR_COM_SIMBOLO = FormatadorValor.getInstance(true);
-
-    /**
-     * Singleton de formatação de boletos bancários.
-     */
-    Formatador BOLETO = FormatadorBoleto.getInstance();
-
-    /**
-     * Singleton de formatação de telefones (DDD) número.
-     */
-    Formatador TELEFONE = FormatadorTelefone.getInstance();
-
-    /**
-     * Singleton de formatação de linha digitável. Transforma números do código de barras em linha
-     * digitável.
-     */
-    Formatador LINHA_DIGITAVEL = FormatadorLinhaDigitavel.getInstance();
-
     /**
      * Formata um valor COMPLETO. Deve falhar caso o valor não esteja completo.
      *
@@ -105,7 +43,7 @@ public interface Formatador {
     /**
      * Classe para guardar os padrões de experssões regulares usados no framework.
      */
-    abstract class Padroes {
+    final class Padroes {
 
         public static final Pattern PADRAO_SOMENTE_NUMEROS = Pattern.compile("[^0-9]");
         public static final Pattern CEP_FORMATADO = Pattern.compile("(\\d{5})-(\\d{3})");
@@ -128,6 +66,76 @@ public interface Formatador {
         );
 
         private Padroes() {
+        }
+    }
+
+    /**
+     * Classe para guardar os singletons
+     */
+    final class Constantes {
+
+        /**
+         * Singleton de formatação de CEP.
+         */
+        public static final Formatador CEP = new FormatadorBase(
+                Padroes.CEP_FORMATADO,
+                "$1-$2",
+                Padroes.CEP_DESFORMATADO,
+                "$1$2"
+        );
+
+        /**
+         * Singleton de formatação de CPF.
+         */
+        public static final Formatador CPF = new FormatadorBase(
+                Padroes.CPF_FORMATADO,
+                "$1.$2.$3-$4",
+                Padroes.CPF_DESFORMATADO,
+                "$1$2$3$4"
+        );
+
+        /**
+         * Singleton de formatação de CNPJ.
+         */
+        public static final Formatador CNPJ = new FormatadorBase(
+                Padroes.CNPJ_FORMATADO,
+                "$1.$2.$3/$4-$5",
+                Padroes.CNPJ_DESFORMATADO,
+                "$1$2$3$4$5"
+        );
+
+        /**
+         * Singleton de formatação de CPF e CNPJ.
+         */
+        public static final Formatador CPF_CNPJ = FormatadorCPFCNPJ.getInstance();
+
+        /**
+         * Singleton de formatação de valores monetários.
+         */
+        public static final FormatadorValor VALOR = FormatadorValor.getInstance(false);
+
+        /**
+         * Singleton de formatação de valores monetários com símbolo do Real.
+         */
+        public static final FormatadorValor VALOR_COM_SIMBOLO = FormatadorValor.getInstance(true);
+
+        /**
+         * Singleton de formatação de boletos bancários.
+         */
+        public static final Formatador BOLETO = FormatadorBoleto.getInstance();
+
+        /**
+         * Singleton de formatação de telefones (DDD) número.
+         */
+        public static final Formatador TELEFONE = FormatadorTelefone.getInstance();
+
+        /**
+         * Singleton de formatação de linha digitável. Transforma números do código de barras em linha
+         * digitável.
+         */
+        public static final Formatador LINHA_DIGITAVEL = FormatadorLinhaDigitavel.getInstance();
+
+        private Constantes() {
         }
     }
 

--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorCEP.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorCEP.java
@@ -14,17 +14,17 @@ public final class FormatadorCEP implements Formatador {
 
     @Override
     public String formata(final String value) {
-        return Formatador.CEP.formata(value);
+        return Formatador.Constantes.CEP.formata(value);
     }
 
     @Override
     public String desformata(final String value) {
-        return Formatador.CEP.desformata(value);
+        return Formatador.Constantes.CEP.desformata(value);
     }
 
     @Override
     public boolean estaFormatado(final String value) {
-        return Formatador.CEP.estaFormatado(value);
+        return Formatador.Constantes.CEP.estaFormatado(value);
     }
 
     @Override
@@ -33,7 +33,7 @@ public final class FormatadorCEP implements Formatador {
             return false;
         }
 
-        return Formatador.CEP.podeSerFormatado(value);
+        return Formatador.Constantes.CEP.podeSerFormatado(value);
     }
 
     private static class SingletonHolder {

--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorCPFCNPJ.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorCPFCNPJ.java
@@ -16,28 +16,28 @@ public final class FormatadorCPFCNPJ implements Formatador {
     @Override
     public String formata(final String value) {
         if (ehCpf(value)) {
-            return Formatador.CPF.formata(value);
+            return Formatador.Constantes.CPF.formata(value);
         }
 
-        return Formatador.CNPJ.formata(value);
+        return Formatador.Constantes.CNPJ.formata(value);
     }
 
     @Override
     public String desformata(final String value) {
         if (ehCpf(value)) {
-            return Formatador.CPF.desformata(value);
+            return Formatador.Constantes.CPF.desformata(value);
         }
 
-        return Formatador.CNPJ.desformata(value);
+        return Formatador.Constantes.CNPJ.desformata(value);
     }
 
     @Override
     public boolean estaFormatado(final String value) {
         if (ehCpf(value)) {
-            return Formatador.CPF.estaFormatado(value);
+            return Formatador.Constantes.CPF.estaFormatado(value);
         }
 
-        return Formatador.CNPJ.estaFormatado(value);
+        return Formatador.Constantes.CNPJ.estaFormatado(value);
     }
 
     @Override
@@ -47,10 +47,10 @@ public final class FormatadorCPFCNPJ implements Formatador {
         }
 
         if (ehCpf(value)) {
-            return Formatador.CPF.podeSerFormatado(value);
+            return Formatador.Constantes.CPF.podeSerFormatado(value);
         }
 
-        return Formatador.CNPJ.podeSerFormatado(value);
+        return Formatador.Constantes.CNPJ.podeSerFormatado(value);
     }
 
     private boolean ehCpf(String value) {

--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorLinhaDigitavel.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorLinhaDigitavel.java
@@ -130,7 +130,7 @@ public final class FormatadorLinhaDigitavel implements Formatador {
 
     @Override
     public boolean estaFormatado(String value) {
-        return Formatador.BOLETO.estaFormatado(value);
+        return Formatador.Constantes.BOLETO.estaFormatado(value);
     }
 
     @Override

--- a/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorValor.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/formatador/FormatadorValor.java
@@ -13,8 +13,8 @@ import java.util.regex.Pattern;
 /**
  * Formatador de valores monetários. Possui duas versões:
  * <ul>
- * <li>Com símbolo do Real {@link Formatador#VALOR_COM_SIMBOLO}</li>
- * <li>Sem símbolo do Real {@link Formatador#VALOR}</li>
+ * <li>Com símbolo do Real {@link Formatador.Constantes#VALOR_COM_SIMBOLO}</li>
+ * <li>Sem símbolo do Real {@link Formatador.Constantes#VALOR}</li>
  * </ul>
  */
 public final class FormatadorValor implements Formatador {

--- a/canarinho/src/main/java/br/com/concrete/canarinho/validator/Validador.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/validator/Validador.java
@@ -14,31 +14,6 @@ import android.text.Editable;
 public interface Validador {
 
     /**
-     * Referência para o singleton de validação de CPF
-     */
-    Validador CPF = ValidadorCPF.getInstance();
-
-    /**
-     * Referência para o singleton de validação de CNPJ
-     */
-    Validador CNPJ = ValidadorCNPJ.getInstance();
-
-    /**
-     * Referência para o singleton de validação de boleto
-     */
-    Validador BOLETO = ValidadorBoleto.getInstance();
-
-    /**
-     * Referência para o singleton de validação de telefone
-     */
-    Validador TELEFONE = ValidadorTelefone.getInstance();
-
-    /**
-     * Referência para o singleton de validação de CEP
-     */
-    Validador CEP = ValidadorCEP.getInstance();
-
-    /**
      * Valida uma {@link String} completa
      *
      * @param valor Valor a ser validado
@@ -108,6 +83,39 @@ public interface Validador {
         public ResultadoParcial mensagem(String mensagem) {
             this.mensagem = mensagem;
             return this;
+        }
+    }
+
+    /**
+     * Classe para guardar os singletons
+     */
+    final class Constantes {
+        /**
+         * Referência para o singleton de validação de CPF
+         */
+        public static final Validador CPF = ValidadorCPF.getInstance();
+
+        /**
+         * Referência para o singleton de validação de CNPJ
+         */
+        public static final Validador CNPJ = ValidadorCNPJ.getInstance();
+
+        /**
+         * Referência para o singleton de validação de boleto
+         */
+        public static final Validador BOLETO = ValidadorBoleto.getInstance();
+
+        /**
+         * Referência para o singleton de validação de telefone
+         */
+        public static final Validador TELEFONE = ValidadorTelefone.getInstance();
+
+        /**
+         * Referência para o singleton de validação de CEP
+         */
+        public static final Validador CEP = ValidadorCEP.getInstance();
+
+        private Constantes() {
         }
     }
 }

--- a/canarinho/src/main/java/br/com/concrete/canarinho/watcher/ValorMonetarioWatcher.java
+++ b/canarinho/src/main/java/br/com/concrete/canarinho/watcher/ValorMonetarioWatcher.java
@@ -34,8 +34,8 @@ public class ValorMonetarioWatcher implements TextWatcher {
      */
     ValorMonetarioWatcher(boolean comSimboloReal, boolean mantemZerosAoLimpar) {
         this.formatador = comSimboloReal
-                ? Formatador.VALOR_COM_SIMBOLO
-                : Formatador.VALOR;
+                ? Formatador.Constantes.VALOR_COM_SIMBOLO
+                : Formatador.Constantes.VALOR;
         this.mantemZerosAoLimpar = mantemZerosAoLimpar;
     }
 

--- a/sample/src/androidTest/java/br/com/concrete/canarinho/sample/BugOnApi28Test.java
+++ b/sample/src/androidTest/java/br/com/concrete/canarinho/sample/BugOnApi28Test.java
@@ -17,13 +17,13 @@ public class BugOnApi28Test {
     @SdkSuppress(minSdkVersion = 28)
     public void moneyFormatSuccessfulRunsOnApi28() {
         final String value = "1.000.000,00";
-        assertEquals("1000000.00", Formatador.VALOR.desformata(value));
+        assertEquals("1000000.00", Formatador.Constantes.VALOR.desformata(value));
     }
 
     @Test
     @SdkSuppress(maxSdkVersion = 27)
     public void moneyFormatSuccessfulRunsOnApi27() {
         final String value = "1.000.000,00";
-        assertEquals("1000000.00", Formatador.VALOR.desformata(value));
+        assertEquals("1000000.00", Formatador.Constantes.VALOR.desformata(value));
     }
 }

--- a/sample/src/main/java/br/com/concrete/canarinho/sample/ui/model/Watchers.java
+++ b/sample/src/main/java/br/com/concrete/canarinho/sample/ui/model/Watchers.java
@@ -54,7 +54,7 @@ public enum Watchers {
             return new MascaraNumericaTextWatcher.Builder()
                     .paraMascara("###.###.###-##")
                     .comCallbackDeValidacao(new SampleEventoDeValidacao(textInputLayout))
-                    .comValidador(Validador.CPF)
+                    .comValidador(Validador.Constantes.CPF)
                     .build();
         }
     },
@@ -70,7 +70,7 @@ public enum Watchers {
             return new MascaraNumericaTextWatcher.Builder()
                     .paraMascara("##.###.###/####-##")
                     .comCallbackDeValidacao(new SampleEventoDeValidacao(textInputLayout))
-                    .comValidador(Validador.CNPJ)
+                    .comValidador(Validador.Constantes.CNPJ)
                     .build();
         }
     },

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorBOLETO.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorBOLETO.java
@@ -10,7 +10,6 @@ import br.com.concrete.canarinho.sample.BuildConfig;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 22)
@@ -18,50 +17,50 @@ public class TesteFormatadorBOLETO {
 
     @Test
     public void consegueFormatar() {
-        assertThat(Formatador.BOLETO.formata("12345123451234512345612345123456712345678901234"),
+        assertThat(Formatador.Constantes.BOLETO.formata("12345123451234512345612345123456712345678901234"),
                 is("12345.12345 12345.123456 12345.123456 7 12345678901234"));
 
-        assertThat(Formatador.BOLETO.formata("23790123016000000005325000456704364670000013580"),
+        assertThat(Formatador.Constantes.BOLETO.formata("23790123016000000005325000456704364670000013580"),
                 is("23790.12301 60000.000053 25000.456704 3 64670000013580"));
 
-        assertThat(Formatador.BOLETO.formata("812345678901812345678901812345678901812345678901"),
+        assertThat(Formatador.Constantes.BOLETO.formata("812345678901812345678901812345678901812345678901"),
                 is("812345678901 812345678901 812345678901 812345678901"));
 
-        assertThat(Formatador.BOLETO.formata("23790.12301 60000.000053 25000.456704 3 64670000013580"),
+        assertThat(Formatador.Constantes.BOLETO.formata("23790.12301 60000.000053 25000.456704 3 64670000013580"),
                 is("23790.12301 60000.000053 25000.456704 3 64670000013580"));
 
-        assertThat(Formatador.BOLETO.formata("812345678901 812345678901 812345678901 812345678901"),
+        assertThat(Formatador.Constantes.BOLETO.formata("812345678901 812345678901 812345678901 812345678901"),
                 is("812345678901 812345678901 812345678901 812345678901"));
     }
 
     @Test
     public void consegueDesformatar() {
 
-        assertThat(Formatador.BOLETO.desformata("12345.12345 12345.123456 12345.123456 7 12345678901234"),
+        assertThat(Formatador.Constantes.BOLETO.desformata("12345.12345 12345.123456 12345.123456 7 12345678901234"),
                 is("12345123451234512345612345123456712345678901234"));
 
-        assertThat(Formatador.BOLETO.desformata("23790.12301 60000.000053 25000.456704 3 64670000013580"),
+        assertThat(Formatador.Constantes.BOLETO.desformata("23790.12301 60000.000053 25000.456704 3 64670000013580"),
                 is("23790123016000000005325000456704364670000013580"));
 
-        assertThat(Formatador.BOLETO.desformata("812345678901 812345678901 812345678901 812345678901"),
+        assertThat(Formatador.Constantes.BOLETO.desformata("812345678901 812345678901 812345678901 812345678901"),
                 is("812345678901812345678901812345678901812345678901"));
 
-        assertThat(Formatador.BOLETO.desformata("23790123016000000005325000456704364670000013580"),
+        assertThat(Formatador.Constantes.BOLETO.desformata("23790123016000000005325000456704364670000013580"),
                 is("23790123016000000005325000456704364670000013580"));
 
-        assertThat(Formatador.BOLETO.desformata("812345678901812345678901812345678901812345678901"),
+        assertThat(Formatador.Constantes.BOLETO.desformata("812345678901812345678901812345678901812345678901"),
                 is("812345678901812345678901812345678901812345678901"));
     }
 
     @Test
     public void consegueDizerSeEstaFormatado() {
 
-        assertThat(Formatador.BOLETO.estaFormatado("12345.12345 12345.123456 12345.123456 7 12345678901234"), is(true));
-        assertThat(Formatador.BOLETO.estaFormatado("23790.12301 60000.000053 25000.456704 3 64670000013580"), is(true));
+        assertThat(Formatador.Constantes.BOLETO.estaFormatado("12345.12345 12345.123456 12345.123456 7 12345678901234"), is(true));
+        assertThat(Formatador.Constantes.BOLETO.estaFormatado("23790.12301 60000.000053 25000.456704 3 64670000013580"), is(true));
 
-        assertThat(Formatador.BOLETO.estaFormatado("812345678901812345678901812345678901812345678901"), is(false));
-        assertThat(Formatador.BOLETO.estaFormatado("23790123016000000005325000456704364670000013580"), is(false));
-        assertThat(Formatador.BOLETO.estaFormatado("812345678901812345678901812345678901812345678901"), is(false));
+        assertThat(Formatador.Constantes.BOLETO.estaFormatado("812345678901812345678901812345678901812345678901"), is(false));
+        assertThat(Formatador.Constantes.BOLETO.estaFormatado("23790123016000000005325000456704364670000013580"), is(false));
+        assertThat(Formatador.Constantes.BOLETO.estaFormatado("812345678901812345678901812345678901812345678901"), is(false));
     }
 
     @Test

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCEP.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCEP.java
@@ -20,11 +20,11 @@ public class TesteFormatadorCEP {
     public void consegueFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CEP.formata("00000-000"), is("00000-000"));
-        assertThat(Formatador.CEP.formata("00000000"), is("00000-000"));
+        assertThat(Formatador.Constantes.CEP.formata("00000-000"), is("00000-000"));
+        assertThat(Formatador.Constantes.CEP.formata("00000000"), is("00000-000"));
 
-        assertThat(Formatador.CEP.formata("12345-123"), is("12345-123"));
-        assertThat(Formatador.CEP.formata("12345678"), is("12345-678"));
+        assertThat(Formatador.Constantes.CEP.formata("12345-123"), is("12345-123"));
+        assertThat(Formatador.Constantes.CEP.formata("12345678"), is("12345-678"));
 
         assertThrowsFormat("");
         assertThrowsFormat("123123");
@@ -34,11 +34,11 @@ public class TesteFormatadorCEP {
     public void consegueDesformatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CEP.desformata("00000-000"), is("00000000"));
-        assertThat(Formatador.CEP.desformata("00000000"), is("00000000"));
+        assertThat(Formatador.Constantes.CEP.desformata("00000-000"), is("00000000"));
+        assertThat(Formatador.Constantes.CEP.desformata("00000000"), is("00000000"));
 
-        assertThat(Formatador.CEP.desformata("12345-123"), is("12345123"));
-        assertThat(Formatador.CEP.desformata("12345678"), is("12345678"));
+        assertThat(Formatador.Constantes.CEP.desformata("12345-123"), is("12345123"));
+        assertThat(Formatador.Constantes.CEP.desformata("12345678"), is("12345678"));
 
         assertThrowsDesformat("");
         assertThrowsDesformat("123123");
@@ -48,15 +48,15 @@ public class TesteFormatadorCEP {
     public void consegueDizerSeEstaFormatado() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CEP.estaFormatado("12345-678"), is(true));
-        assertThat(Formatador.CEP.estaFormatado("12345678"), is(false));
-        assertThat(Formatador.CEP.estaFormatado("00000-000"), is(true));
-        assertThat(Formatador.CEP.estaFormatado("12345-67"), is(false));
+        assertThat(Formatador.Constantes.CEP.estaFormatado("12345-678"), is(true));
+        assertThat(Formatador.Constantes.CEP.estaFormatado("12345678"), is(false));
+        assertThat(Formatador.Constantes.CEP.estaFormatado("00000-000"), is(true));
+        assertThat(Formatador.Constantes.CEP.estaFormatado("12345-67"), is(false));
 
-        assertThat(Formatador.CEP.estaFormatado("047486"), is(false));
-        assertThat(Formatador.CEP.estaFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CEP.estaFormatado("047486"), is(false));
+        assertThat(Formatador.Constantes.CEP.estaFormatado(""), is(false));
         try {
-            Formatador.CEP.estaFormatado(null);
+            Formatador.Constantes.CEP.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -66,16 +66,16 @@ public class TesteFormatadorCEP {
     public void consegueDizerSePodeFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CEP.podeSerFormatado("12345-678"), is(false));
-        assertThat(Formatador.CEP.podeSerFormatado("12345678"), is(true));
-        assertThat(Formatador.CEP.podeSerFormatado("020"), is(false));
-        assertThat(Formatador.CEP.podeSerFormatado(""), is(false));
-        assertThat(Formatador.CEP.podeSerFormatado(null), is(false));
+        assertThat(Formatador.Constantes.CEP.podeSerFormatado("12345-678"), is(false));
+        assertThat(Formatador.Constantes.CEP.podeSerFormatado("12345678"), is(true));
+        assertThat(Formatador.Constantes.CEP.podeSerFormatado("020"), is(false));
+        assertThat(Formatador.Constantes.CEP.podeSerFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CEP.podeSerFormatado(null), is(false));
     }
 
     private void assertThrowsFormat(String valor) {
         try {
-            Formatador.CEP.formata(valor);
+            Formatador.Constantes.CEP.formata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -83,7 +83,7 @@ public class TesteFormatadorCEP {
 
     private void assertThrowsDesformat(String valor) {
         try {
-            Formatador.CEP.desformata(valor);
+            Formatador.Constantes.CEP.desformata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCNPJ.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCNPJ.java
@@ -20,14 +20,14 @@ public class TesteFormatadorCNPJ {
     public void consegueFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CNPJ.formata("50.713.534/0001-33"), is("50.713.534/0001-33"));
-        assertThat(Formatador.CNPJ.formata("50713534000133"), is("50.713.534/0001-33"));
+        assertThat(Formatador.Constantes.CNPJ.formata("50.713.534/0001-33"), is("50.713.534/0001-33"));
+        assertThat(Formatador.Constantes.CNPJ.formata("50713534000133"), is("50.713.534/0001-33"));
 
-        assertThat(Formatador.CNPJ.formata("72.606.598/0001-78"), is("72.606.598/0001-78"));
-        assertThat(Formatador.CNPJ.formata("72606598000178"), is("72.606.598/0001-78"));
+        assertThat(Formatador.Constantes.CNPJ.formata("72.606.598/0001-78"), is("72.606.598/0001-78"));
+        assertThat(Formatador.Constantes.CNPJ.formata("72606598000178"), is("72.606.598/0001-78"));
 
-        assertThat(Formatador.CNPJ.formata("23.106.535/0001-47"), is("23.106.535/0001-47"));
-        assertThat(Formatador.CNPJ.formata("23106535000147"), is("23.106.535/0001-47"));
+        assertThat(Formatador.Constantes.CNPJ.formata("23.106.535/0001-47"), is("23.106.535/0001-47"));
+        assertThat(Formatador.Constantes.CNPJ.formata("23106535000147"), is("23.106.535/0001-47"));
 
         assertThrowsFormat("");
         assertThrowsFormat("123123");
@@ -39,14 +39,14 @@ public class TesteFormatadorCNPJ {
     public void consegueDesformatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CNPJ.desformata("50.713.534/0001-33"), is("50713534000133"));
-        assertThat(Formatador.CNPJ.desformata("50713534000133"), is("50713534000133"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("50.713.534/0001-33"), is("50713534000133"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("50713534000133"), is("50713534000133"));
 
-        assertThat(Formatador.CNPJ.desformata("72.606.598/0001-78"), is("72606598000178"));
-        assertThat(Formatador.CNPJ.desformata("72606598000178"), is("72606598000178"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("72.606.598/0001-78"), is("72606598000178"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("72606598000178"), is("72606598000178"));
 
-        assertThat(Formatador.CNPJ.desformata("23.106.535/0001-47"), is("23106535000147"));
-        assertThat(Formatador.CNPJ.desformata("23106535000147"), is("23106535000147"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("23.106.535/0001-47"), is("23106535000147"));
+        assertThat(Formatador.Constantes.CNPJ.desformata("23106535000147"), is("23106535000147"));
 
         assertThrowsDesformat("");
         assertThrowsDesformat("123123");
@@ -58,15 +58,15 @@ public class TesteFormatadorCNPJ {
     public void consegueDizerSeEstaFormatado() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CNPJ.estaFormatado("72.606.598/0001-78"), is(true));
-        assertThat(Formatador.CNPJ.estaFormatado("72606598000178"), is(false));
-        assertThat(Formatador.CNPJ.estaFormatado("23.106.535/0001-47"), is(true));
-        assertThat(Formatador.CNPJ.estaFormatado("23106535000147"), is(false));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado("72.606.598/0001-78"), is(true));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado("72606598000178"), is(false));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado("23.106.535/0001-47"), is(true));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado("23106535000147"), is(false));
 
-        assertThat(Formatador.CNPJ.estaFormatado("047486"), is(false));
-        assertThat(Formatador.CNPJ.estaFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado("047486"), is(false));
+        assertThat(Formatador.Constantes.CNPJ.estaFormatado(""), is(false));
         try {
-            Formatador.CNPJ.estaFormatado(null);
+            Formatador.Constantes.CNPJ.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -76,16 +76,16 @@ public class TesteFormatadorCNPJ {
     public void consegueDizerSePodeFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CNPJ.podeSerFormatado("23.106.535/0001-47"), is(false));
-        assertThat(Formatador.CNPJ.podeSerFormatado("23106535000147"), is(true));
-        assertThat(Formatador.CNPJ.podeSerFormatado("020"), is(false));
-        assertThat(Formatador.CNPJ.podeSerFormatado(""), is(false));
-        assertThat(Formatador.CNPJ.podeSerFormatado(null), is(false));
+        assertThat(Formatador.Constantes.CNPJ.podeSerFormatado("23.106.535/0001-47"), is(false));
+        assertThat(Formatador.Constantes.CNPJ.podeSerFormatado("23106535000147"), is(true));
+        assertThat(Formatador.Constantes.CNPJ.podeSerFormatado("020"), is(false));
+        assertThat(Formatador.Constantes.CNPJ.podeSerFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CNPJ.podeSerFormatado(null), is(false));
     }
 
     private void assertThrowsFormat(String valor) {
         try {
-            Formatador.CNPJ.formata(valor);
+            Formatador.Constantes.CNPJ.formata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -93,7 +93,7 @@ public class TesteFormatadorCNPJ {
 
     private void assertThrowsDesformat(String valor) {
         try {
-            Formatador.CNPJ.desformata(valor);
+            Formatador.Constantes.CNPJ.desformata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCPF.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCPF.java
@@ -20,17 +20,17 @@ public class TesteFormatadorCPF {
     public void consegueFormatarCPF() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF.formata("545.586.262-66"), is("545.586.262-66"));
-        assertThat(Formatador.CPF.formata("54558626266"), is("545.586.262-66"));
+        assertThat(Formatador.Constantes.CPF.formata("545.586.262-66"), is("545.586.262-66"));
+        assertThat(Formatador.Constantes.CPF.formata("54558626266"), is("545.586.262-66"));
 
-        assertThat(Formatador.CPF.formata("020.724.833-87"), is("020.724.833-87"));
-        assertThat(Formatador.CPF.formata("02072483387"), is("020.724.833-87"));
+        assertThat(Formatador.Constantes.CPF.formata("020.724.833-87"), is("020.724.833-87"));
+        assertThat(Formatador.Constantes.CPF.formata("02072483387"), is("020.724.833-87"));
 
-        assertThat(Formatador.CPF.formata("188.527.045-31"), is("188.527.045-31"));
-        assertThat(Formatador.CPF.formata("18852704531"), is("188.527.045-31"));
+        assertThat(Formatador.Constantes.CPF.formata("188.527.045-31"), is("188.527.045-31"));
+        assertThat(Formatador.Constantes.CPF.formata("18852704531"), is("188.527.045-31"));
 
-        assertThat(Formatador.CPF.formata("047.486.777-32"), is("047.486.777-32"));
-        assertThat(Formatador.CPF.formata("04748677732"), is("047.486.777-32"));
+        assertThat(Formatador.Constantes.CPF.formata("047.486.777-32"), is("047.486.777-32"));
+        assertThat(Formatador.Constantes.CPF.formata("04748677732"), is("047.486.777-32"));
 
         assertThrowsFormat("");
         assertThrowsFormat("123123");
@@ -42,17 +42,17 @@ public class TesteFormatadorCPF {
     public void consegueDesformatarCPF() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF.desformata("545.586.262-66"), is("54558626266"));
-        assertThat(Formatador.CPF.desformata("54558626266"), is("54558626266"));
+        assertThat(Formatador.Constantes.CPF.desformata("545.586.262-66"), is("54558626266"));
+        assertThat(Formatador.Constantes.CPF.desformata("54558626266"), is("54558626266"));
 
-        assertThat(Formatador.CPF.desformata("020.724.833-87"), is("02072483387"));
-        assertThat(Formatador.CPF.desformata("02072483387"), is("02072483387"));
+        assertThat(Formatador.Constantes.CPF.desformata("020.724.833-87"), is("02072483387"));
+        assertThat(Formatador.Constantes.CPF.desformata("02072483387"), is("02072483387"));
 
-        assertThat(Formatador.CPF.desformata("188.527.045-31"), is("18852704531"));
-        assertThat(Formatador.CPF.desformata("18852704531"), is("18852704531"));
+        assertThat(Formatador.Constantes.CPF.desformata("188.527.045-31"), is("18852704531"));
+        assertThat(Formatador.Constantes.CPF.desformata("18852704531"), is("18852704531"));
 
-        assertThat(Formatador.CPF.desformata("047.486.777-32"), is("04748677732"));
-        assertThat(Formatador.CPF.desformata("04748677732"), is("04748677732"));
+        assertThat(Formatador.Constantes.CPF.desformata("047.486.777-32"), is("04748677732"));
+        assertThat(Formatador.Constantes.CPF.desformata("04748677732"), is("04748677732"));
 
         assertThrowsDesformat("");
         assertThrowsDesformat("123123");
@@ -64,19 +64,19 @@ public class TesteFormatadorCPF {
     public void consegueDizerSeEstaFormatado() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF.estaFormatado("545.586.262-66"), is(true));
-        assertThat(Formatador.CPF.estaFormatado("54558626266"), is(false));
-        assertThat(Formatador.CPF.estaFormatado("020.724.833-87"), is(true));
-        assertThat(Formatador.CPF.estaFormatado("02072483387"), is(false));
-        assertThat(Formatador.CPF.estaFormatado("188.527.045-31"), is(true));
-        assertThat(Formatador.CPF.estaFormatado("18852704531"), is(false));
-        assertThat(Formatador.CPF.estaFormatado("047.486.777-32"), is(true));
-        assertThat(Formatador.CPF.estaFormatado("04748677732"), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("545.586.262-66"), is(true));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("54558626266"), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("020.724.833-87"), is(true));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("02072483387"), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("188.527.045-31"), is(true));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("18852704531"), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("047.486.777-32"), is(true));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("04748677732"), is(false));
 
-        assertThat(Formatador.CPF.estaFormatado("047486"), is(false));
-        assertThat(Formatador.CPF.estaFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado("047486"), is(false));
+        assertThat(Formatador.Constantes.CPF.estaFormatado(""), is(false));
         try {
-            Formatador.CPF.estaFormatado(null);
+            Formatador.Constantes.CPF.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -86,16 +86,16 @@ public class TesteFormatadorCPF {
     public void consegueDizerSePodeFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF.podeSerFormatado("545.586.262-66"), is(false));
-        assertThat(Formatador.CPF.podeSerFormatado("54558626266"), is(true));
-        assertThat(Formatador.CPF.podeSerFormatado("020"), is(false));
-        assertThat(Formatador.CPF.podeSerFormatado(""), is(false));
-        assertThat(Formatador.CPF.podeSerFormatado(null), is(false));
+        assertThat(Formatador.Constantes.CPF.podeSerFormatado("545.586.262-66"), is(false));
+        assertThat(Formatador.Constantes.CPF.podeSerFormatado("54558626266"), is(true));
+        assertThat(Formatador.Constantes.CPF.podeSerFormatado("020"), is(false));
+        assertThat(Formatador.Constantes.CPF.podeSerFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF.podeSerFormatado(null), is(false));
     }
 
     private void assertThrowsFormat(String valor) {
         try {
-            Formatador.CPF.formata(valor);
+            Formatador.Constantes.CPF.formata(valor);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -103,7 +103,7 @@ public class TesteFormatadorCPF {
 
     private void assertThrowsDesformat(String valor) {
         try {
-            Formatador.CPF.desformata(valor);
+            Formatador.Constantes.CPF.desformata(valor);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCPFCNPJ.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorCPFCNPJ.java
@@ -20,14 +20,14 @@ public class TesteFormatadorCPFCNPJ {
     public void consegueFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.formata("50.713.534/0001-33"), is("50.713.534/0001-33"));
-        assertThat(Formatador.CPF_CNPJ.formata("50713534000133"), is("50.713.534/0001-33"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("50.713.534/0001-33"), is("50.713.534/0001-33"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("50713534000133"), is("50.713.534/0001-33"));
 
-        assertThat(Formatador.CPF_CNPJ.formata("72.606.598/0001-78"), is("72.606.598/0001-78"));
-        assertThat(Formatador.CPF_CNPJ.formata("72606598000178"), is("72.606.598/0001-78"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("72.606.598/0001-78"), is("72.606.598/0001-78"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("72606598000178"), is("72.606.598/0001-78"));
 
-        assertThat(Formatador.CPF_CNPJ.formata("23.106.535/0001-47"), is("23.106.535/0001-47"));
-        assertThat(Formatador.CPF_CNPJ.formata("23106535000147"), is("23.106.535/0001-47"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("23.106.535/0001-47"), is("23.106.535/0001-47"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("23106535000147"), is("23.106.535/0001-47"));
 
         assertThrowsFormat("");
         assertThrowsFormat("123123");
@@ -35,17 +35,17 @@ public class TesteFormatadorCPFCNPJ {
         assertThrowsFormat("       23.106.535/0001-47      ");
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.formata("545.586.262-66"), is("545.586.262-66"));
-        assertThat(Formatador.CPF_CNPJ.formata("54558626266"), is("545.586.262-66"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("545.586.262-66"), is("545.586.262-66"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("54558626266"), is("545.586.262-66"));
 
-        assertThat(Formatador.CPF_CNPJ.formata("020.724.833-87"), is("020.724.833-87"));
-        assertThat(Formatador.CPF_CNPJ.formata("02072483387"), is("020.724.833-87"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("020.724.833-87"), is("020.724.833-87"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("02072483387"), is("020.724.833-87"));
 
-        assertThat(Formatador.CPF_CNPJ.formata("188.527.045-31"), is("188.527.045-31"));
-        assertThat(Formatador.CPF_CNPJ.formata("18852704531"), is("188.527.045-31"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("188.527.045-31"), is("188.527.045-31"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("18852704531"), is("188.527.045-31"));
 
-        assertThat(Formatador.CPF_CNPJ.formata("047.486.777-32"), is("047.486.777-32"));
-        assertThat(Formatador.CPF_CNPJ.formata("04748677732"), is("047.486.777-32"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("047.486.777-32"), is("047.486.777-32"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.formata("04748677732"), is("047.486.777-32"));
 
         assertThrowsFormat("");
         assertThrowsFormat("123123");
@@ -57,14 +57,14 @@ public class TesteFormatadorCPFCNPJ {
     public void consegueDesformatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.desformata("50.713.534/0001-33"), is("50713534000133"));
-        assertThat(Formatador.CPF_CNPJ.desformata("50713534000133"), is("50713534000133"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("50.713.534/0001-33"), is("50713534000133"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("50713534000133"), is("50713534000133"));
 
-        assertThat(Formatador.CPF_CNPJ.desformata("72.606.598/0001-78"), is("72606598000178"));
-        assertThat(Formatador.CPF_CNPJ.desformata("72606598000178"), is("72606598000178"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("72.606.598/0001-78"), is("72606598000178"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("72606598000178"), is("72606598000178"));
 
-        assertThat(Formatador.CPF_CNPJ.desformata("23.106.535/0001-47"), is("23106535000147"));
-        assertThat(Formatador.CPF_CNPJ.desformata("23106535000147"), is("23106535000147"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("23.106.535/0001-47"), is("23106535000147"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("23106535000147"), is("23106535000147"));
 
         assertThrowsDesformat("");
         assertThrowsDesformat("123123");
@@ -72,17 +72,17 @@ public class TesteFormatadorCPFCNPJ {
         assertThrowsDesformat("       047.486.777-32      ");
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.desformata("545.586.262-66"), is("54558626266"));
-        assertThat(Formatador.CPF_CNPJ.desformata("54558626266"), is("54558626266"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("545.586.262-66"), is("54558626266"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("54558626266"), is("54558626266"));
 
-        assertThat(Formatador.CPF_CNPJ.desformata("020.724.833-87"), is("02072483387"));
-        assertThat(Formatador.CPF_CNPJ.desformata("02072483387"), is("02072483387"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("020.724.833-87"), is("02072483387"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("02072483387"), is("02072483387"));
 
-        assertThat(Formatador.CPF_CNPJ.desformata("188.527.045-31"), is("18852704531"));
-        assertThat(Formatador.CPF_CNPJ.desformata("18852704531"), is("18852704531"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("188.527.045-31"), is("18852704531"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("18852704531"), is("18852704531"));
 
-        assertThat(Formatador.CPF_CNPJ.desformata("047.486.777-32"), is("04748677732"));
-        assertThat(Formatador.CPF_CNPJ.desformata("04748677732"), is("04748677732"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("047.486.777-32"), is("04748677732"));
+        assertThat(Formatador.Constantes.CPF_CNPJ.desformata("04748677732"), is("04748677732"));
 
         assertThrowsDesformat("");
         assertThrowsDesformat("123123");
@@ -94,33 +94,33 @@ public class TesteFormatadorCPFCNPJ {
     public void consegueDizerSeEstaFormatado() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("72.606.598/0001-78"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("72606598000178"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("23.106.535/0001-47"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("23106535000147"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("72.606.598/0001-78"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("72606598000178"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("23.106.535/0001-47"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("23106535000147"), is(false));
 
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("047486"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("047486"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado(""), is(false));
         try {
-            Formatador.CPF_CNPJ.estaFormatado(null);
+            Formatador.Constantes.CPF_CNPJ.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("545.586.262-66"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("54558626266"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("020.724.833-87"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("02072483387"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("188.527.045-31"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("18852704531"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("047.486.777-32"), is(true));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("04748677732"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("545.586.262-66"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("54558626266"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("020.724.833-87"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("02072483387"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("188.527.045-31"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("18852704531"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("047.486.777-32"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("04748677732"), is(false));
 
-        assertThat(Formatador.CPF_CNPJ.estaFormatado("047486"), is(false));
-        assertThat(Formatador.CPF_CNPJ.estaFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado("047486"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.estaFormatado(""), is(false));
         try {
-            Formatador.CPF_CNPJ.estaFormatado(null);
+            Formatador.Constantes.CPF_CNPJ.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -130,23 +130,23 @@ public class TesteFormatadorCPFCNPJ {
     public void consegueDizerSePodeFormatar() {
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("23.106.535/0001-47"), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("23106535000147"), is(true));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("020"), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado(""), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado(null), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("23.106.535/0001-47"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("23106535000147"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("020"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado(null), is(false));
 
         // Gerados automaticamente para testes
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("545.586.262-66"), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("54558626266"), is(true));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado("020"), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado(""), is(false));
-        assertThat(Formatador.CPF_CNPJ.podeSerFormatado(null), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("545.586.262-66"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("54558626266"), is(true));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado("020"), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado(""), is(false));
+        assertThat(Formatador.Constantes.CPF_CNPJ.podeSerFormatado(null), is(false));
     }
 
     private void assertThrowsFormat(String valor) {
         try {
-            Formatador.CPF_CNPJ.formata(valor);
+            Formatador.Constantes.CPF_CNPJ.formata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -154,7 +154,7 @@ public class TesteFormatadorCPFCNPJ {
 
     private void assertThrowsDesformat(String valor) {
         try {
-            Formatador.CPF_CNPJ.desformata(valor);
+            Formatador.Constantes.CPF_CNPJ.desformata(valor);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorLinhaDigitavel.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorLinhaDigitavel.java
@@ -19,26 +19,26 @@ public class TesteFormatadorLinhaDigitavel {
     @Test
     public void consegueFormatarEDesformatar() {
 
-        assertThat(Formatador.LINHA_DIGITAVEL.desformata("812345678901812345678901812345678901812345678901"),
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.desformata("812345678901812345678901812345678901812345678901"),
                 is("81234567890812345678908123456789081234567890"));
 
         final String original = "23790123016000000005325000456704964680000013580";
-        final String boleto = Formatador.LINHA_DIGITAVEL.desformata(original);
-        final String linhaDigitavel = Formatador.LINHA_DIGITAVEL.formata(boleto);
+        final String boleto = Formatador.Constantes.LINHA_DIGITAVEL.desformata(original);
+        final String linhaDigitavel = Formatador.Constantes.LINHA_DIGITAVEL.formata(boleto);
 
         assertThat(linhaDigitavel, equalTo(original));
     }
 
     @Test
     public void consegueDizerSeEstaFormatado() {
-        assertThat(Formatador.LINHA_DIGITAVEL.estaFormatado("81234567890812345678908123456789081234567890"), is(false));
-        assertThat(Formatador.LINHA_DIGITAVEL.estaFormatado("812345678901 812345678901 812345678901 812345678901"), is(true));
-        assertThat(Formatador.LINHA_DIGITAVEL.estaFormatado("23790.12301 60000.000053 25000.456704 9 64680000013580"), is(true));
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.estaFormatado("81234567890812345678908123456789081234567890"), is(false));
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.estaFormatado("812345678901 812345678901 812345678901 812345678901"), is(true));
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.estaFormatado("23790.12301 60000.000053 25000.456704 9 64680000013580"), is(true));
     }
 
     @Test
     public void consegueDizerSePodeFormatar() {
-        assertThat(Formatador.LINHA_DIGITAVEL.podeSerFormatado("8123456789081234567890812345678908123456"), is(false));
-        assertThat(Formatador.LINHA_DIGITAVEL.podeSerFormatado("23790.1230 60000.00005 25000.45670 9 64680000013580"), is(true));
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.podeSerFormatado("8123456789081234567890812345678908123456"), is(false));
+        assertThat(Formatador.Constantes.LINHA_DIGITAVEL.podeSerFormatado("23790.1230 60000.00005 25000.45670 9 64680000013580"), is(true));
     }
 }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorTelefone.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorTelefone.java
@@ -18,14 +18,14 @@ public class TesteFormatadorTelefone {
 
     @Test
     public void consegueFormatar() {
-        assertThat(Formatador.TELEFONE.formata("1112345678"),
+        assertThat(Formatador.Constantes.TELEFONE.formata("1112345678"),
                 is("(11) 1234-5678"));
 
-        assertThat(Formatador.TELEFONE.formata("11123456789"),
+        assertThat(Formatador.Constantes.TELEFONE.formata("11123456789"),
                 is("(11) 12345-6789"));
 
         try {
-            Formatador.TELEFONE.formata(null);
+            Formatador.Constantes.TELEFONE.formata(null);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -33,14 +33,14 @@ public class TesteFormatadorTelefone {
 
     @Test
     public void consegueDesformatar() {
-        assertThat(Formatador.TELEFONE.desformata("(11) 1234-5678"),
+        assertThat(Formatador.Constantes.TELEFONE.desformata("(11) 1234-5678"),
                 is("1112345678"));
 
-        assertThat(Formatador.TELEFONE.desformata("(11) 12345-6789"),
+        assertThat(Formatador.Constantes.TELEFONE.desformata("(11) 12345-6789"),
                 is("11123456789"));
 
         try {
-            Formatador.TELEFONE.desformata(null);
+            Formatador.Constantes.TELEFONE.desformata(null);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -48,15 +48,15 @@ public class TesteFormatadorTelefone {
 
     @Test
     public void consegueDizerSeEstaFormatado() {
-        assertThat(Formatador.TELEFONE.estaFormatado("(11) 1234-5678"), is(true));
-        assertThat(Formatador.TELEFONE.estaFormatado("(11) 12345-6789"), is(true));
+        assertThat(Formatador.Constantes.TELEFONE.estaFormatado("(11) 1234-5678"), is(true));
+        assertThat(Formatador.Constantes.TELEFONE.estaFormatado("(11) 12345-6789"), is(true));
 
-        assertThat(Formatador.TELEFONE.estaFormatado("(11) 1234-56789"), is(false));
-        assertThat(Formatador.TELEFONE.estaFormatado("1112345678"), is(false));
-        assertThat(Formatador.TELEFONE.estaFormatado("11123456789"), is(false));
+        assertThat(Formatador.Constantes.TELEFONE.estaFormatado("(11) 1234-56789"), is(false));
+        assertThat(Formatador.Constantes.TELEFONE.estaFormatado("1112345678"), is(false));
+        assertThat(Formatador.Constantes.TELEFONE.estaFormatado("11123456789"), is(false));
 
         try {
-            Formatador.TELEFONE.estaFormatado(null);
+            Formatador.Constantes.TELEFONE.estaFormatado(null);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -64,14 +64,14 @@ public class TesteFormatadorTelefone {
 
     @Test
     public void consegueDizerSePodeFormatar() {
-        assertThat(Formatador.TELEFONE.podeSerFormatado("11"), is(false));
-        assertThat(Formatador.TELEFONE.podeSerFormatado("111234567890"), is(false));
+        assertThat(Formatador.Constantes.TELEFONE.podeSerFormatado("11"), is(false));
+        assertThat(Formatador.Constantes.TELEFONE.podeSerFormatado("111234567890"), is(false));
 
-        assertThat(Formatador.TELEFONE.podeSerFormatado("1112345678"), is(true));
-        assertThat(Formatador.TELEFONE.podeSerFormatado("11123456789"), is(true));
+        assertThat(Formatador.Constantes.TELEFONE.podeSerFormatado("1112345678"), is(true));
+        assertThat(Formatador.Constantes.TELEFONE.podeSerFormatado("11123456789"), is(true));
 
         try {
-            Formatador.TELEFONE.podeSerFormatado(null);
+            Formatador.Constantes.TELEFONE.podeSerFormatado(null);
             fail("Deveria ter jogado exceção!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorValor.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteFormatadorValor.java
@@ -6,7 +6,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import br.com.concrete.canarinho.formatador.Formatador;
-import br.com.concrete.canarinho.formatador.FormatadorValor;
 import br.com.concrete.canarinho.sample.BuildConfig;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,56 +19,56 @@ public class TesteFormatadorValor {
     @Test
     public void consegueFormatar() {
 
-        assertThat(Formatador.VALOR.formata("1.00"), is("1,00"));
-        assertThat(Formatador.VALOR.formata("1.0"), is("1,00"));
-        assertThat(Formatador.VALOR.formata("1"), is("1,00"));
-        assertThat(Formatador.VALOR.formata("1000"), is("1.000,00"));
-        assertThat(Formatador.VALOR.formata("1.23"), is("1,23"));
-        assertThat(Formatador.VALOR.formata("1.233"), is("1,23"));
-        assertThat(Formatador.VALOR.formata("1.01"), is("1,01"));
-        assertThat(Formatador.VALOR.formata("1.1"), is("1,10"));
-        assertThat(Formatador.VALOR.formata("1234.56"), is("1.234,56"));
-        assertThat(Formatador.VALOR.formata("1234.5"), is("1.234,50"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.00"), is("1,00"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.0"), is("1,00"));
+        assertThat(Formatador.Constantes.VALOR.formata("1"), is("1,00"));
+        assertThat(Formatador.Constantes.VALOR.formata("1000"), is("1.000,00"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.23"), is("1,23"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.233"), is("1,23"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.01"), is("1,01"));
+        assertThat(Formatador.Constantes.VALOR.formata("1.1"), is("1,10"));
+        assertThat(Formatador.Constantes.VALOR.formata("1234.56"), is("1.234,56"));
+        assertThat(Formatador.Constantes.VALOR.formata("1234.5"), is("1.234,50"));
     }
 
     @Test
     public void consegueFormatarComSimbolo() {
 
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.00"), is("R$ 1,00"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.0"), is("R$ 1,00"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1"), is("R$ 1,00"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1000"), is("R$ 1.000,00"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.23"), is("R$ 1,23"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.233"), is("R$ 1,23"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.01"), is("R$ 1,01"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1.1"), is("R$ 1,10"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1234.56"), is("R$ 1.234,56"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.formata("1234.5"), is("R$ 1.234,50"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.00"), is("R$ 1,00"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.0"), is("R$ 1,00"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1"), is("R$ 1,00"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1000"), is("R$ 1.000,00"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.23"), is("R$ 1,23"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.233"), is("R$ 1,23"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.01"), is("R$ 1,01"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1.1"), is("R$ 1,10"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1234.56"), is("R$ 1.234,56"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.formata("1234.5"), is("R$ 1.234,50"));
     }
 
     @Test
     public void consegueDesformatar() {
-        assertThat(Formatador.VALOR.desformata("1,00"), is("1.00"));
-        assertThat(Formatador.VALOR.desformata("1.234,10"), is("1234.10"));
-        assertThat(Formatador.VALOR.desformata("0,10"), is("0.10"));
+        assertThat(Formatador.Constantes.VALOR.desformata("1,00"), is("1.00"));
+        assertThat(Formatador.Constantes.VALOR.desformata("1.234,10"), is("1234.10"));
+        assertThat(Formatador.Constantes.VALOR.desformata("0,10"), is("0.10"));
     }
 
     @Test
     public void consegueDesformatarComSimbolo() {
-        assertThat(Formatador.VALOR_COM_SIMBOLO.desformata("R$ 1,00"), is("1.00"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.desformata("R$ 1.234,10"), is("1234.10"));
-        assertThat(Formatador.VALOR_COM_SIMBOLO.desformata("R$ 0,10"), is("0.10"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.desformata("R$ 1,00"), is("1.00"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.desformata("R$ 1.234,10"), is("1234.10"));
+        assertThat(Formatador.Constantes.VALOR_COM_SIMBOLO.desformata("R$ 0,10"), is("0.10"));
     }
 
     @Test
     public void consegueDizerSeEstaFormatado() {
 
-        assertThat(Formatador.VALOR.estaFormatado("1,00"), is(true));
-        assertThat(Formatador.VALOR.estaFormatado("1.234,10"), is(true));
-        assertThat(Formatador.VALOR.estaFormatado("1.34,10"), is(false));
+        assertThat(Formatador.Constantes.VALOR.estaFormatado("1,00"), is(true));
+        assertThat(Formatador.Constantes.VALOR.estaFormatado("1.234,10"), is(true));
+        assertThat(Formatador.Constantes.VALOR.estaFormatado("1.34,10"), is(false));
 
         try {
-            Formatador.VALOR.estaFormatado(null);
+            Formatador.Constantes.VALOR.estaFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }
@@ -78,13 +77,13 @@ public class TesteFormatadorValor {
     @Test
     public void consegueDizerSePodeFormatar() {
 
-        assertThat(Formatador.VALOR.podeSerFormatado("1.00"), is(true));
-        assertThat(Formatador.VALOR.podeSerFormatado("10"), is(true));
-        assertThat(Formatador.VALOR.podeSerFormatado("10.1"), is(true));
-        assertThat(Formatador.VALOR.podeSerFormatado("10,10"), is(false));
+        assertThat(Formatador.Constantes.VALOR.podeSerFormatado("1.00"), is(true));
+        assertThat(Formatador.Constantes.VALOR.podeSerFormatado("10"), is(true));
+        assertThat(Formatador.Constantes.VALOR.podeSerFormatado("10.1"), is(true));
+        assertThat(Formatador.Constantes.VALOR.podeSerFormatado("10,10"), is(false));
 
         try {
-            Formatador.VALOR.podeSerFormatado(null);
+            Formatador.Constantes.VALOR.podeSerFormatado(null);
             fail("Should have thrown!!!");
         } catch (IllegalArgumentException e) {
         }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/TesteValidadores.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/TesteValidadores.java
@@ -6,8 +6,12 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import br.com.concrete.canarinho.sample.BuildConfig;
-import br.com.concrete.canarinho.validator.Validador;
 
+import static br.com.concrete.canarinho.validator.Validador.Constantes.BOLETO;
+import static br.com.concrete.canarinho.validator.Validador.Constantes.CEP;
+import static br.com.concrete.canarinho.validator.Validador.Constantes.CNPJ;
+import static br.com.concrete.canarinho.validator.Validador.Constantes.CPF;
+import static br.com.concrete.canarinho.validator.Validador.Constantes.TELEFONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -19,117 +23,117 @@ public class TesteValidadores {
     public void consegueValidarCPF() {
 
         // Gerados automaticamente para testes
-        assertThat(Validador.CPF.ehValido("545.586.262-66"), is(true));
-        assertThat(Validador.CPF.ehValido("655.274.921-02"), is(true));
-        assertThat(Validador.CPF.ehValido("020.724.833-87"), is(true));
-        assertThat(Validador.CPF.ehValido("188.527.045-31"), is(true));
-        assertThat(Validador.CPF.ehValido("047.486.777-32"), is(true));
+        assertThat(CPF.ehValido("545.586.262-66"), is(true));
+        assertThat(CPF.ehValido("655.274.921-02"), is(true));
+        assertThat(CPF.ehValido("020.724.833-87"), is(true));
+        assertThat(CPF.ehValido("188.527.045-31"), is(true));
+        assertThat(CPF.ehValido("047.486.777-32"), is(true));
 
-        assertThat(Validador.CPF.ehValido("54558626266"), is(true));
-        assertThat(Validador.CPF.ehValido("65527492102"), is(true));
-        assertThat(Validador.CPF.ehValido("02072483387"), is(true));
-        assertThat(Validador.CPF.ehValido("18852704531"), is(true));
-        assertThat(Validador.CPF.ehValido("04748677732"), is(true));
+        assertThat(CPF.ehValido("54558626266"), is(true));
+        assertThat(CPF.ehValido("65527492102"), is(true));
+        assertThat(CPF.ehValido("02072483387"), is(true));
+        assertThat(CPF.ehValido("18852704531"), is(true));
+        assertThat(CPF.ehValido("04748677732"), is(true));
 
-        assertThat(Validador.CPF.ehValido("545.111.262-66"), is(false));
-        assertThat(Validador.CPF.ehValido("655.111.921-02"), is(false));
-        assertThat(Validador.CPF.ehValido("020.111.833-87"), is(false));
-        assertThat(Validador.CPF.ehValido("188.111.045-31"), is(false));
-        assertThat(Validador.CPF.ehValido("047.111.777-32"), is(false));
+        assertThat(CPF.ehValido("545.111.262-66"), is(false));
+        assertThat(CPF.ehValido("655.111.921-02"), is(false));
+        assertThat(CPF.ehValido("020.111.833-87"), is(false));
+        assertThat(CPF.ehValido("188.111.045-31"), is(false));
+        assertThat(CPF.ehValido("047.111.777-32"), is(false));
 
-        assertThat(Validador.CPF.ehValido("54111626266"), is(false));
-        assertThat(Validador.CPF.ehValido("65111492102"), is(false));
-        assertThat(Validador.CPF.ehValido("02111483387"), is(false));
-        assertThat(Validador.CPF.ehValido("18111704531"), is(false));
-        assertThat(Validador.CPF.ehValido("04111677732"), is(false));
+        assertThat(CPF.ehValido("54111626266"), is(false));
+        assertThat(CPF.ehValido("65111492102"), is(false));
+        assertThat(CPF.ehValido("02111483387"), is(false));
+        assertThat(CPF.ehValido("18111704531"), is(false));
+        assertThat(CPF.ehValido("04111677732"), is(false));
     }
 
     @Test
     public void consegueValidarCNPJ() {
 
         // Gerados automaticamente para testes
-        assertThat(Validador.CNPJ.ehValido("50.713.534/0001-33"), is(true));
-        assertThat(Validador.CNPJ.ehValido("77.135.038/0001-04"), is(true));
-        assertThat(Validador.CNPJ.ehValido("58.613.246/0001-19"), is(true));
-        assertThat(Validador.CNPJ.ehValido("50713534000133"), is(true));
-        assertThat(Validador.CNPJ.ehValido("77135038000104"), is(true));
+        assertThat(CNPJ.ehValido("50.713.534/0001-33"), is(true));
+        assertThat(CNPJ.ehValido("77.135.038/0001-04"), is(true));
+        assertThat(CNPJ.ehValido("58.613.246/0001-19"), is(true));
+        assertThat(CNPJ.ehValido("50713534000133"), is(true));
+        assertThat(CNPJ.ehValido("77135038000104"), is(true));
 
         // Gerados automaticamente para testes
-        assertThat(Validador.CNPJ.ehValido("50.713.111/0001-33"), is(false));
-        assertThat(Validador.CNPJ.ehValido("77.135.111/0001-04"), is(false));
-        assertThat(Validador.CNPJ.ehValido("50713531110133"), is(false));
-        assertThat(Validador.CNPJ.ehValido("77135031110104"), is(false));
+        assertThat(CNPJ.ehValido("50.713.111/0001-33"), is(false));
+        assertThat(CNPJ.ehValido("77.135.111/0001-04"), is(false));
+        assertThat(CNPJ.ehValido("50713531110133"), is(false));
+        assertThat(CNPJ.ehValido("77135031110104"), is(false));
     }
 
     @Test
     public void consegueValidarBoletoNormal() {
 
         // boleto bradesco
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("23790.12301 60000.000053 25000.456704 9 64680000013580"), is(true));
 
         // boleto bradesco
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("23790123016000000005325000456704964680000013580"), is(true));
 
         // boleto banco do brasil
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("00199.38414 90480.002550 84666.970219 4 64290000007726"), is(true));
 
 
         // Boleto itau desformatado
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("34191750090000159091820521070001664890002370000"), is(true));
 
         // Boleto itau
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("34191.75009 00001.590918 20521.070001 6 64890002370000"), is(true));
 
         // boleto Banestes
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("02190.00015 05000.000017 23452.021696 2 25230000034000"), is(true));
 
         // boleto Caixa
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("10491.44338 55119.000002 00000.000141 3 25230000093423"), is(true));
 
         // boleto Sudameris
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("34790.12001 12345.695006 10502.000002 5 25230000034000"), is(true));
     }
 
     @Test
     public void consegueValidarBoletoTributoSemSerTaxa() {
 
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("848600000015 523301622010 506101307129 620012111220"), is(true));
     }
 
     @Test
     public void consegueValidarBoletoTributoDeTaxa() {
 
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("836600000019 078800481000 998854924516 001265611135"), is(true));
 
-        assertThat(Validador.BOLETO
+        assertThat(BOLETO
                 .ehValido("826100000007 265400971429 620232390612 725103150621"), is(true));
     }
 
     @Test
     public void consegueValidarTelefone() {
-        assertThat(Validador.TELEFONE.ehValido("1112345678"), is(true));
-        assertThat(Validador.TELEFONE.ehValido("11123456789"), is(true));
-        assertThat(Validador.TELEFONE.ehValido("(11) 12345-6789"), is(true));
-        assertThat(Validador.TELEFONE.ehValido("111234567890"), is(false));
-        assertThat(Validador.TELEFONE.ehValido("1112345"), is(false));
+        assertThat(TELEFONE.ehValido("1112345678"), is(true));
+        assertThat(TELEFONE.ehValido("11123456789"), is(true));
+        assertThat(TELEFONE.ehValido("(11) 12345-6789"), is(true));
+        assertThat(TELEFONE.ehValido("111234567890"), is(false));
+        assertThat(TELEFONE.ehValido("1112345"), is(false));
     }
 
     @Test
     public void consegueValidarCEP() {
-        assertThat(Validador.CEP.ehValido("12345678"), is(true));
-        assertThat(Validador.CEP.ehValido("12345-678"), is(true));
-        assertThat(Validador.CEP.ehValido("12345-67"), is(false));
-        assertThat(Validador.CEP.ehValido("1234-678"), is(false));
-        assertThat(Validador.CEP.ehValido(""), is(false));
+        assertThat(CEP.ehValido("12345678"), is(true));
+        assertThat(CEP.ehValido("12345-678"), is(true));
+        assertThat(CEP.ehValido("12345-67"), is(false));
+        assertThat(CEP.ehValido("1234-678"), is(false));
+        assertThat(CEP.ehValido(""), is(false));
     }
 }

--- a/sample/src/test/java/br/com/concrete/canarinho/test/watcher/ValorMonetarioWatcherTest.java
+++ b/sample/src/test/java/br/com/concrete/canarinho/test/watcher/ValorMonetarioWatcherTest.java
@@ -9,9 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.annotation.Config;
 
-import br.com.concrete.canarinho.sample.BuildConfig;
 import br.com.concrete.canarinho.watcher.ValorMonetarioWatcher;
 
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
# Extrai constantes da interface para uma classe própria
Ao usar e ao implementar novos Formatadores acabamos entrando em contato com as constantes que estão dentro das interfaces.

## Tipo de mudança
- [ ] Bug fix 
- [ ] Nova Feature
- [x] Melhoria
- [ ] Outra?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/concretesolutions/canarinho/47)
<!-- Reviewable:end -->
